### PR TITLE
Fixed prefab sorting in ComponentUpgrade

### DIFF
--- a/Plugins/TextToTMP/Editor/ComponentUpgrade.cs
+++ b/Plugins/TextToTMP/Editor/ComponentUpgrade.cs
@@ -9,8 +9,6 @@ using UnityEngine.Events;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
-using Object = UnityEngine.Object;
-using Random = UnityEngine.Random;
 
 namespace TextToTMPNamespace
 {


### PR DESCRIPTION
Due to a bug in prefab sorting (the used comparison isn't reflexive, transitive, anti-symmetric), the tool sometimes upgrades nested prefabs after their parent prefabs and base prefabs after their variants, leading to issues such as converting a single Text component into two TextMeshProUGUI components etc. 
This pull request fixes the problem.